### PR TITLE
Suggestion - Move disableTimeeouts check

### DIFF
--- a/gohttp/client_core.go
+++ b/gohttp/client_core.go
@@ -98,11 +98,11 @@ func (c *httpClient) getResponseTimeout() time.Duration {
 }
 
 func (c *httpClient) getConnectionTimeout() time.Duration {
-	if c.builder.connectionTimeout > 0 {
-		return c.builder.connectionTimeout
-	}
 	if c.builder.disableTimeouts {
 		return 0
+	}
+	if c.builder.connectionTimeout > 0 {
+		return c.builder.connectionTimeout
 	}
 	return defaultConnectionTimeout
 }


### PR DESCRIPTION
Just a suggestion in the getConnectionTimeout method

Move the disableTimeouts check first, in the event someone sets disableTimeouts to true, but also sets the connectionTimeout to some value, which would result in disableTimouts not being executed.